### PR TITLE
Round the change to 3 decimals

### DIFF
--- a/src/Crypto/Currency.php
+++ b/src/Crypto/Currency.php
@@ -66,7 +66,7 @@ class Currency
      */
     public function getChange()
     {
-        return $this->change;
+        return round($this->change, 3);
     }
 
     /**


### PR DESCRIPTION
CoinMarketCap has a change precision of 6 decimals and they are too many characters for lametric's screen.

With this change we round it to just 3 decimals, that is still very good enough precision, so that the whole number will fit.