### PR TITLE
fix / trim user input of currency

### DIFF
--- a/src/Crypto/Validator.php
+++ b/src/Crypto/Validator.php
@@ -34,7 +34,7 @@ class Validator
         for ($i = 1; $i <= 20; $i++) {
             $key = 'currency' . $i;
             if (isset($this->parameters[$key]) && $this->parameters[$key] !== '') {
-                $this->data['codes'][] = strtoupper($this->parameters[$key]);
+                $this->data['codes'][] = strtoupper(trim($this->parameters[$key]));
             }
         }
 


### PR DESCRIPTION
Hey, great app!
On mobile when the keyboard autocompletes, there is a space after the currency code. At least it happened to me (Samsung Galaxy S20+). This would fix it. 
Could not test it though.