### PR TITLE
(fix) Add 'TON' to the list of coins not to duplicate

### DIFF
--- a/cron/cryptoprices.php
+++ b/cron/cryptoprices.php
@@ -14,7 +14,8 @@ const COINS_TO_NOT_DUPLICATE = [
     'IOT',
     'DOGE',
     'BTC',
-    'ETH'
+    'ETH',
+    'TON'
 ];
 
 use GuzzleHttp\Client as GuzzleClient;


### PR DESCRIPTION
Fixes the problem of incorrect value of TON coin